### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-#vali.js
+# vali.js
 中文API地址：http://1029131145.github.io/vali/
 
-#使用方法
+# 使用方法
 ```javascript
 <!-- 非常简单 -->
 <form class="form">


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
